### PR TITLE
Add plain text diffing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,7 @@ gem 'rspec', '~> 3.4'
 gem 'rest-client', '~> 1.8'
 gem 'govuk-lint', '~> 0.5'
 gem 'diffy', '~> 3.1'
+
+group :development, :test do
+  gem 'pry-byebug'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,9 @@ GEM
     ast (2.1.0)
     astrolabe (1.3.1)
       parser (~> 2.2)
+    byebug (8.2.1)
     casperjs (1.0.0)
+    coderay (1.1.0)
     diff-lcs (1.2.5)
     diffy (3.1.0)
     domain_name (0.5.25)
@@ -34,6 +36,7 @@ GEM
       domain_name (~> 0.5)
     image_size (1.4.1)
     log4r (1.1.10)
+    method_source (0.8.2)
     mime-types (2.6.2)
     mini_portile2 (2.0.0)
     netrc (0.11.0)
@@ -43,6 +46,13 @@ GEM
     parser (2.2.3.0)
       ast (>= 1.1, < 3.0)
     powerpack (0.1.1)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.3.0)
+      byebug (~> 8.0)
+      pry (~> 0.10)
     rainbow (2.0.0)
     rake (10.4.2)
     rest-client (1.8.0)
@@ -71,6 +81,7 @@ GEM
       ruby-progressbar (~> 1.7)
       tins (<= 1.6.0)
     ruby-progressbar (1.7.5)
+    slop (3.6.0)
     thor (0.19.1)
     tins (1.6.0)
     unf (0.1.4)
@@ -83,6 +94,10 @@ PLATFORMS
 DEPENDENCIES
   diffy (~> 3.1)
   govuk-lint (~> 0.5)
+  pry-byebug
   rest-client (~> 1.8)
   rspec (~> 3.4)
   wraith!
+
+BUNDLED WITH
+   1.10.6

--- a/lib/tasks/rakefile.rake
+++ b/lib/tasks/rakefile.rake
@@ -14,6 +14,28 @@ namespace :diff do
     require_relative '../html_diff/runner'
     HtmlDiff::Runner.new.run
   end
+
+  desc 'produce text diffs'
+  task :text do
+    require_relative '../text_diff/runner'
+
+    if ARGV.tap(&:shift).empty?
+      abort "You must provide one or more YAML files containing the pages to diff"
+    end
+
+    left  = ENV.fetch("LEFT", "www-origin.staging.publishing.service.gov.uk")
+    right = ENV.fetch("RIGHT", "www-origin.publishing.service.gov.uk")
+
+    require 'yaml'
+
+    ARGV.each do |file|
+      TextDiff::Runner.new(
+        pages: YAML.load_file(file),
+        left_domain: left,
+        right_domain: right
+      ).run
+    end
+  end
 end
 
 namespace :config do

--- a/lib/text_diff/differ.rb
+++ b/lib/text_diff/differ.rb
@@ -1,0 +1,9 @@
+require 'diffy'
+
+module TextDiff
+  class Differ
+    def diff(left, right)
+      Diffy::Diff.new(left, right).to_s
+    end
+  end
+end

--- a/lib/text_diff/formatter.rb
+++ b/lib/text_diff/formatter.rb
@@ -1,0 +1,9 @@
+require 'nokogiri'
+
+module TextDiff
+  class Formatter
+    def call(html)
+      Nokogiri::HTML(html).xpath("//text()").text
+    end
+  end
+end

--- a/lib/text_diff/renderer.rb
+++ b/lib/text_diff/renderer.rb
@@ -1,0 +1,17 @@
+module TextDiff
+  class Renderer
+    SEPARATOR = "\n\n".freeze
+
+    def initialize(kernel = Kernel)
+      @kernel = kernel
+    end
+
+    def call(responses)
+      if responses.all?(&:empty?)
+        puts 'OK!'
+      else
+        @kernel.abort responses.join(SEPARATOR)
+      end
+    end
+  end
+end

--- a/lib/text_diff/retriever.rb
+++ b/lib/text_diff/retriever.rb
@@ -1,0 +1,7 @@
+module TextDiff
+  class Retriever
+    def call(url)
+      `curl -s #{url}`
+    end
+  end
+end

--- a/lib/text_diff/runner.rb
+++ b/lib/text_diff/runner.rb
@@ -1,0 +1,40 @@
+require_relative 'differ'
+require_relative 'renderer'
+require_relative 'retriever'
+require_relative 'formatter'
+
+module TextDiff
+  class Runner
+    def initialize(
+      pages: Array.new,
+      differ: Differ.new,
+      retriever: Retriever.new,
+      formatter: Formatter.new,
+      renderer: Renderer.new,
+      left_domain: "www-origin.staging.publishing.service.gov.uk",
+      right_domain: "www-origin.publishing.service.gov.uk"
+    )
+      @pages     = pages
+      @differ    = differ
+      @retriever = retriever
+      @formatter = formatter
+      @renderer  = renderer
+      @left_domain  = left_domain
+      @right_domain = right_domain
+    end
+
+    def run
+      responses = @pages.inject([]) do |response, page|
+        left  = @retriever.call("https://#{@left_domain}/#{page}")
+        right = @retriever.call("https://#{@right_domain}/#{page}")
+
+        response << @differ.diff(
+          @formatter.call(left),
+          @formatter.call(right)
+        )
+      end
+
+      @renderer.call(responses)
+    end
+  end
+end

--- a/spec/text_diff/differ_spec.rb
+++ b/spec/text_diff/differ_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../lib/text_diff/differ'
+
+RSpec.describe TextDiff::Differ do
+  it 'returns the diff from given texts' do
+    expect(described_class.new.diff("a\n", "b\n")).to eq("-a\n+b\n")
+  end
+end

--- a/spec/text_diff/formatter_spec.rb
+++ b/spec/text_diff/formatter_spec.rb
@@ -1,0 +1,16 @@
+require_relative '../../lib/text_diff/formatter'
+
+RSpec.describe TextDiff::Formatter do
+  describe '#call' do
+    it 'strips HTML from the given argument and returns plain text' do
+      {
+        %(<html><body>abcd</body></html>)       => 'abcd',
+        %(<a href="http://google.com">whoa</a>) => 'whoa',
+        %(abc efgh ijkl)                        => 'abc efgh ijkl',
+        %(<a>malformed html whoops)             => 'malformed html whoops',
+      }.each do |html, text|
+        expect(described_class.new.call(html)).to eq(text)
+      end
+    end
+  end
+end

--- a/spec/text_diff/renderer_spec.rb
+++ b/spec/text_diff/renderer_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../../lib/text_diff/renderer'
+
+RSpec.describe TextDiff::Renderer do
+  context 'with empty diffs' do
+    it 'puts an OK message to STDOUT' do
+      expect { described_class.new.call(['']) }.to output("OK!\n").to_stdout
+    end
+  end
+
+  context 'with diffs' do
+    let(:kernel) { double }
+
+    it 'aborts with the diffs to STDERR' do
+      expect(kernel).to receive(:abort).with(an_instance_of(String))
+
+      described_class.new(kernel).call(["-meh\n+beh\n"])
+    end
+  end
+end

--- a/spec/text_diff/runner_spec.rb
+++ b/spec/text_diff/runner_spec.rb
@@ -1,0 +1,38 @@
+require_relative '../../lib/text_diff/runner'
+
+RSpec.describe TextDiff::Runner do
+  let(:pages) { %w(a) }
+  let(:retriever) { double }
+  let(:formatter) { double }
+  let(:renderer) { double }
+
+  before do
+    allow(retriever).to receive(:call).with(/www-origin.publishing/).and_return('<h1>Tiny Rick</h1>')
+    allow(retriever).to receive(:call).with(/www-origin.staging/).and_return('<h1>Tiny</h1>')
+    allow(renderer).to receive(:call)
+  end
+
+  describe '#run' do
+    context 'for each given page' do
+      it 'retrieves the staging and production HTML' do
+        expect(retriever).to receive(:call).with(/www-origin.publishing/).and_return('<h1>Tiny Rick</h1>')
+        expect(retriever).to receive(:call).with(/www-origin.staging/).and_return('<h1>Tiny</h1>')
+
+        described_class.new(pages: pages, retriever: retriever, renderer: renderer).run
+      end
+
+      it 'strips HTML and returns the plain text' do
+        expect(formatter).to receive(:call).with('<h1>Tiny Rick</h1>').and_return('Tiny Rick')
+        expect(formatter).to receive(:call).with('<h1>Tiny</h1>').and_return('Tiny')
+
+        described_class.new(pages: pages, retriever: retriever, formatter: formatter, renderer: renderer).run
+      end
+
+      it 'calls the renderer' do
+        expect(renderer).to receive(:call)
+
+        described_class.new(pages: pages, retriever: retriever, renderer: renderer).run
+      end
+    end
+  end
+end


### PR DESCRIPTION
Diffs staging and production pages by stripping the HTML and comparing
just the plain text versions.

Usage:

```
    $ bundle exec rake diff:text pages.yml
```

Where `pages.yml` is a YAML file containing an array of pages. For
example:

```
- browse/benefits
- jobsearch
- apply-apprenticeship
```

You may also specify the `LEFT` and `RIGHT` domains using the
aforementioned environment variables. They default to our
`www-origin.staging` and `www-origin.publishing` domains respectively.

If any diffs are found, the task will abort with a non-zero exit code
and print the diff text to `STDERR`. Otherwise return successfully.

Can be parallelized by temporarily splitting the input files (using
`CSPLIT(1)` or something) and piping to multiple processes.
