### PR TITLE
Lint Ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'wraith', git: 'git@github.com:alphagov/wraith.git', branch: 'psr'
+gem 'govuk-lint', '~> 0.8'
 
 gemspec

--- a/govuk-diff-pages.gemspec
+++ b/govuk-diff-pages.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Ben Lovell"]
   spec.email         = ["benjamin.lovell@gmail.com"]
 
-  spec.summary       = %q{Visual and textual page diffing.}
-  spec.description   = %q{Diffs web pages both visually and textually.}
+  spec.summary       = 'Visual and textual page diffing.'
+  spec.description   = 'Diffs web pages both visually and textually.'
   spec.homepage      = "https://github.com/alphagov/govuk-diff-pages"
   spec.license       = "MIT"
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -6,6 +6,11 @@ rm -f Gemfile.lock
 git clean -fdx
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
+
+if [[ ${GIT_BRANCH} != "origin/master" ]]; then
+  bundle exec govuk-lint-ruby --format clang
+fi
+
 bundle exec rake
 
 if [[ -n "$PUBLISH_GEM" ]]; then

--- a/lib/govuk/diff/pages/app_config.rb
+++ b/lib/govuk/diff/pages/app_config.rb
@@ -43,6 +43,7 @@ module Govuk
         end
 
       private
+
         def populate_config(hash)
           config = OpenStruct.new
           hash.each do |key, value|

--- a/lib/govuk/diff/pages/html_diff/differ.rb
+++ b/lib/govuk/diff/pages/html_diff/differ.rb
@@ -34,6 +34,7 @@ module Govuk
           end
 
         private
+
           def reset_html_diffs_dir
             Dir.mkdir(@diff_dir) unless Dir.exist?(@diff_dir)
             FileUtils.rm Dir.glob("#{@diff_dir}/*")

--- a/lib/govuk/diff/pages/html_diff/runner.rb
+++ b/lib/govuk/diff/pages/html_diff/runner.rb
@@ -22,6 +22,7 @@ module Govuk
           end
 
         private
+
           def create_gallery_page
             @result_hash = @differ.differing_pages
             shots_dir = "#{Govuk::Diff::Pages.root_dir}/#{@config.html_diff.directory}"

--- a/lib/govuk/diff/pages/link_checker.rb
+++ b/lib/govuk/diff/pages/link_checker.rb
@@ -19,6 +19,7 @@ module Govuk
         end
 
       private
+
         def print_results
           puts "Number of pages checked: #{@num_links}"
           puts "  of which:"

--- a/lib/govuk/diff/pages/page_indexer.rb
+++ b/lib/govuk/diff/pages/page_indexer.rb
@@ -18,6 +18,7 @@ module Govuk
         end
 
       private
+
         def get_formats
           @formats = FormatSearcher.new(@config).run
         end

--- a/lib/govuk/diff/pages/page_searcher.rb
+++ b/lib/govuk/diff/pages/page_searcher.rb
@@ -25,6 +25,7 @@ module Govuk
         end
 
       private
+
         def top_pages_for_format(format)
           result_set = JSON.parse(result_set_for_format(format))
           extract_top_govuk_pages(result_set)

--- a/lib/govuk/diff/pages/tasks/rakefile.rake
+++ b/lib/govuk/diff/pages/tasks/rakefile.rake
@@ -40,7 +40,7 @@ namespace :config do
   task :pre_flight_check do
     puts "Checking required packages installed."
     dependencies_present = true
-    {imagemagick: 'convert', phantomjs: 'phantomjs'}.each do |package, binary|
+    { imagemagick: 'convert', phantomjs: 'phantomjs' }.each do |package, binary|
       print "#{package}..... "
       result = %x[ which #{binary} ]
       if result.empty?

--- a/lib/govuk/diff/pages/wraith_config_generator.rb
+++ b/lib/govuk/diff/pages/wraith_config_generator.rb
@@ -35,6 +35,7 @@ module Govuk
         end
 
       private
+
         def validate_hard_coded_pages
           errors = []
           @config.hard_coded_pages.to_h.each do |_key, url|

--- a/spec/govuk/diff/pages/format_searcher_spec.rb
+++ b/spec/govuk/diff/pages/format_searcher_spec.rb
@@ -3,17 +3,17 @@ describe Govuk::Diff::Pages::FormatSearcher do
     it 'returns and array of formats' do
       SEARCH_API_RESPONSE = {
        "facets" =>
-        {"format" =>
-          {"options" =>
-            [{"value" => {"slug" => "publication"}, "documents" => 81996},
-             {"value" => {"slug" => "news_article"}, "documents" => 44322},
-             {"value" => {"slug" => "aaib_report"}, "documents" => 9735},
-             {"value" => {"slug" => "world_location_news_article"}, "documents" => 8827},
+        { "format" =>
+          { "options" =>
+            [{ "value" => { "slug" => "publication" }, "documents" => 81996 },
+             { "value" => { "slug" => "news_article" }, "documents" => 44322 },
+             { "value" => { "slug" => "aaib_report" }, "documents" => 9735 },
+             { "value" => { "slug" => "world_location_news_article" }, "documents" => 8827 },
              ],
            "documents_with_no_value" => 0,
            "total_options" => 58,
            "missing_options" => 0,
-           "scope" => "exclude_field_filter"}},
+           "scope" => "exclude_field_filter" } },
        "suggested_queries" => []
       }.to_json
       config = Govuk::Diff::Pages::AppConfig.new(File.dirname(__FILE__) + '/../../../test_config.yml')

--- a/spec/govuk/diff/pages/html_diff/differ_spec.rb
+++ b/spec/govuk/diff/pages/html_diff/differ_spec.rb
@@ -74,7 +74,7 @@ describe Govuk::Diff::Pages::HtmlDiff::Differ do
       it 'adds the base path to the list of differing pages' do
         expect(differ).to receive(:write_diff_page).with(target_base_path, instance_of(String))
         differ.diff(target_base_path)
-        expect(differ.differing_pages).to eq({target_base_path => "#{Govuk::Diff::Pages.root_dir}/html_diff_dir/my_base_path.html"})
+        expect(differ.differing_pages).to eq(target_base_path => "#{Govuk::Diff::Pages.root_dir}/html_diff_dir/my_base_path.html")
       end
     end
   end

--- a/spec/govuk/diff/pages/wraith_config_generator_spec.rb
+++ b/spec/govuk/diff/pages/wraith_config_generator_spec.rb
@@ -1,5 +1,5 @@
 describe Govuk::Diff::Pages::WraithConfigGenerator do
-  let(:settings_file) { "#{Govuk::Diff::Pages.root_dir}/config/settings.yml"}
+  let(:settings_file) { "#{Govuk::Diff::Pages.root_dir}/config/settings.yml" }
   let(:standard_config) {
     {
       "domains" => {


### PR DESCRIPTION
Lints Ruby code per our styleguide.

Closes #7 in favour of this PR against the existing #6 branch.
