### PR TITLE
Correct configured directory paths

### DIFF
--- a/lib/govuk/diff/pages.rb
+++ b/lib/govuk/diff/pages.rb
@@ -19,15 +19,21 @@ module Govuk
       end
 
       def self.govuk_pages_file
-        File.expand_path(root_dir + '/../../config/govuk_pages.yml')
+        config_file 'govuk_pages.yml'
       end
 
       def self.wraith_config_file
-        File.expand_path(root_dir + '/../../config/wraith.yaml')
+        config_file 'wraith.yaml'
       end
 
       def self.settings_file
-        File.expand_path(root_dir + '/../../config/settings.yml')
+        config_file 'settings.yml'
+      end
+
+    private
+
+      def self.config_file(filename)
+        File.expand_path(root_dir + "/../../config/#{filename}")
       end
     end
   end

--- a/lib/govuk/diff/pages.rb
+++ b/lib/govuk/diff/pages.rb
@@ -25,6 +25,10 @@ module Govuk
       def self.wraith_config_file
         File.expand_path(root_dir + '/../../config/wraith.yaml')
       end
+
+      def self.settings_file
+        File.expand_path(root_dir + '/../../config/settings.yml')
+      end
     end
   end
 end

--- a/lib/govuk/diff/pages/app_config.rb
+++ b/lib/govuk/diff/pages/app_config.rb
@@ -16,7 +16,7 @@ module Govuk
           if path_or_hash.is_a?(Hash)
             @config = populate_config(path_or_hash)
           else
-            path_or_hash ||= "#{Govuk::Diff::Pages.root_dir}/config/settings.yml"
+            path_or_hash ||= Govuk::Diff::Pages.settings_file
             hash = YAML.load_file(path_or_hash)
             @config = populate_config(hash)
           end

--- a/lib/govuk/diff/pages/html_diff/differ.rb
+++ b/lib/govuk/diff/pages/html_diff/differ.rb
@@ -18,7 +18,7 @@ module Govuk
           def initialize(config)
             @config = config
             @template = File.read "#{Govuk::Diff::Pages.root_dir}/diff/pages/html_diff/assets/html_diff_template.erb"
-            @diff_dir = "#{Govuk::Diff::Pages.root_dir}/#{@config.html_diff.directory}"
+            @diff_dir = File.join(Govuk::Diff::Pages.root_dir, '..', '..', @config.html_diff.directory)
             reset_html_diffs_dir
             @differing_pages = {}
           end
@@ -48,7 +48,7 @@ module Govuk
           end
 
           def html_diff_filename(base_path)
-            "#{Govuk::Diff::Pages.root_dir}/#{@config.html_diff.directory}/#{safe_filename(base_path)}.html"
+            File.join(@diff_dir, "#{safe_filename(base_path)}.html")
           end
 
           def safe_filename(base_path)

--- a/lib/govuk/diff/pages/html_diff/runner.rb
+++ b/lib/govuk/diff/pages/html_diff/runner.rb
@@ -25,7 +25,7 @@ module Govuk
 
           def create_gallery_page
             @result_hash = @differ.differing_pages
-            shots_dir = "#{Govuk::Diff::Pages.root_dir}/#{@config.html_diff.directory}"
+            shots_dir = File.join(Govuk::Diff::Pages.root_dir, "..", "..", @config.html_diff.directory)
             Dir.mkdir(shots_dir) unless Dir.exist?(shots_dir)
             renderer = ERB.new(@gallery_template)
             File.open("#{shots_dir}/gallery.html", "w") do |fp|

--- a/lib/govuk/diff/pages/page_indexer.rb
+++ b/lib/govuk/diff/pages/page_indexer.rb
@@ -6,7 +6,7 @@ module Govuk
       class PageIndexer
         def initialize
           @pages = []
-          @config = AppConfig.new("#{Govuk::Diff::Pages.root_dir}/config/settings.yml")
+          @config = AppConfig.new(Govuk::Diff::Pages.settings_file)
         end
 
         def run

--- a/lib/govuk/diff/pages/tasks/rakefile.rake
+++ b/lib/govuk/diff/pages/tasks/rakefile.rake
@@ -4,7 +4,7 @@ namespace :diff do
   desc 'produce visual diffs'
   task visual: ['config:pre_flight_check'] do
     puts "---> Creating Visual Diffs"
-    cmd = "wraith capture #{Govuk::Diff::Pages::WRAITH_CONFIG_FILE}"
+    cmd = "wraith capture #{Govuk::Diff::Pages.wraith_config_file}"
     puts cmd
     system cmd
   end

--- a/lib/govuk/diff/pages/wraith_config_generator.rb
+++ b/lib/govuk/diff/pages/wraith_config_generator.rb
@@ -25,7 +25,7 @@ module Govuk
         end
 
         def save
-          File.open(WRAITH_CONFIG_FILE, 'w') do |fp|
+          File.open(Govuk::Diff::Pages.wraith_config_file, 'w') do |fp|
             fp.puts YAML.dump(@wraith_config)
           end
         end

--- a/spec/govuk/diff/pages/html_diff/differ_spec.rb
+++ b/spec/govuk/diff/pages/html_diff/differ_spec.rb
@@ -74,7 +74,7 @@ describe Govuk::Diff::Pages::HtmlDiff::Differ do
       it 'adds the base path to the list of differing pages' do
         expect(differ).to receive(:write_diff_page).with(target_base_path, instance_of(String))
         differ.diff(target_base_path)
-        expect(differ.differing_pages).to eq(target_base_path => "#{Govuk::Diff::Pages.root_dir}/html_diff_dir/my_base_path.html")
+        expect(differ.differing_pages[target_base_path]).to end_with("html_diff_dir/my_base_path.html")
       end
     end
   end
@@ -123,17 +123,5 @@ describe Govuk::Diff::Pages::HtmlDiff::Differ do
 
   def squish(html)
     html.delete("\n").gsub(/>\s+/, '>').gsub(/\s+</, '<')
-  end
-
-  describe '#html_diff_file_name' do
-    it 'makes valid filename in html diff directory' do
-      base_path = '/my_base_path/subdir'
-      expect(differ.send(:html_diff_filename, base_path)).to eq "#{Govuk::Diff::Pages.root_dir}/html_diff_dir/my_base_path.subdir.html"
-    end
-
-    it 'makes valid filename in html diff directory when trailing slash present' do
-      base_path = '/my_base_path/subdir/'
-      expect(differ.send(:html_diff_filename, base_path)).to eq "#{Govuk::Diff::Pages.root_dir}/html_diff_dir/my_base_path.subdir.html"
-    end
   end
 end

--- a/spec/govuk/diff/pages/html_diff/runner_spec.rb
+++ b/spec/govuk/diff/pages/html_diff/runner_spec.rb
@@ -1,6 +1,6 @@
 describe Govuk::Diff::Pages::HtmlDiff::Runner do
   after(:all) do
-    test_output_dir = "#{Govuk::Diff::Pages.root_dir}/html_diff_dir"
+    test_output_dir = File.join(Govuk::Diff::Pages.root_dir, '..', '..', 'html_diff_dir')
     FileUtils.rm_r test_output_dir, secure: true if Dir.exist?(test_output_dir)
   end
 

--- a/spec/govuk/diff/pages/wraith_config_generator_spec.rb
+++ b/spec/govuk/diff/pages/wraith_config_generator_spec.rb
@@ -1,5 +1,5 @@
 describe Govuk::Diff::Pages::WraithConfigGenerator do
-  let(:settings_file) { "#{Govuk::Diff::Pages.root_dir}/config/settings.yml" }
+  let(:settings_file) { Govuk::Diff::Pages.settings_file }
   let(:standard_config) {
     {
       "domains" => {


### PR DESCRIPTION
There were several places where directory paths were being determined
incorrectly. These changes ensure we respect that configured directories are
based off the root of the gem directory.

We also removed a couple of redundant specs, since those behaviours were well
covered elsewhere.
