### PR TITLE
Doc updates and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,56 @@
 # govuk-diff-pages
 
-This project provides a rake task to produce visual diffs as screenshots, HTML
-diffs and textual diffs of the production GOV.UK website as compared with
-staging. Viewable as browser pages or directly in the terminal.
+This app provides a set of rake tasks that produce diffs of the staging and
+production GOV.UK websites. Diffs are provided in 3 distinct forms:
 
-## Screenshots
+* Visual
+  * Screenshots of pages in each environment, compared and presented in an HTML
+    gallery for viewing in a browser.
+* HTML
+  * Diffs of the markup on each page, also presented in gallery form.
+* Text
+  * Diffs of text content on each page, with the results sent to STDOUT.
 
+## Visual Diffs
+These use a fork of the BBC's wraith gem (https://github.com/alphagov/wraith).
+The fork adds two extra configuration variables, allowing the user to specify
+the number of threads to use, and the maximum timeout when loading pages.
+
+### Running
+The rake task expects an env var `URI` to be set - this should be the location
+of a YAML file containing a list of GOV.UK paths to run the diff against. See
+spec/fixtures/test_paths.yaml for an example.
+
+    bundle exec rake diff:visual URI=https://uri/to/a/yaml/file.yaml
+
+Results are written to `$PROJECT_ROOT/results/visual/gallery.html`.
+
+### Dependencies
+The following are required in order to run a visual diff. A pre-flight check
+for these dependencies runs when you execute the `diff:visual` task.
+
+- [ImageMagick](http://www.imagemagick.org/script/index.php)
+- [phantomjs](http://phantomjs.org/) - preferrably 1.9 rather than 2.0
+
+### Examples
 ![Example output](docs/screenshots/gallery.png?raw=true "Example gallery of
 differing pages")
 
+## HTML Diffs
+These use Diffy gem (https://github.com/samg/diffy) as the underlying diff
+library.
 
-## Technical documentation for visual and HTML diffs
+### Running
+Expects `URI` to be set, as with Visual Diffs.
 
-It uses a fork of the BBC's wraith gem (The fork is at
-https://github.com/alphagov/wraith, the main gem at
-https://github.com/BBC-News/wraith).  The fork adds two extra configuration
-variables, allowing the user to specify the number of threads to use, and the
-maximum timeout when loading pages.  The output is written to an html file
-which can be viewed in a browser.
+    bundle exec rake diff:html URI=https://uri/to/a/yaml/file.yaml
 
-When `bundle exec rake diff` is run, a list of all the document formats on
-govuk is obtained using the search api, and then the top n pages for each
-format (n being a configuration variable).  Diffs are produced for each of
-these pages.
+Results are written to `$PROJECT_ROOT/results/html/gallery.html`.
 
+## Text Diffs
+These also use Diffy gem.
 
-### Dependencies
-
-- [ImageMagick] (http://www.imagemagick.org/script/index.php)
-- [phantomjs] (http://phantomjs.org/) - preferrably 1.9 rather than 2.0
-
-## How to run
-
-### Running the application locally
-
-    bundle exec rake diff
-
-### Checking plain-text diffs
-
+### Running
     bundle exec rake diff:text pages.yml
 
 Where `pages.yml` is a YAML array of paths to compare. For example:
@@ -55,20 +68,9 @@ environment variables. Defaulting to our `www-origin.staging` and
 Plain-text diffing can be parallelised by starting multiple processes with
 individual page files.
 
-### Using the gem from an existing project
+## Running the test suite
 
-    # Gemfile
-    gem 'govuk-diff-pages'
-
-    # Rakefile
-    load 'govuk/diff/pages/tasks/rakefile.rake'
-
-    # Shell
-    bundle exec rake -T
-
-### Running the test suite
-
-    bundle exec rake
+    bundle exec rspec
 
 ## Licence
 

--- a/lib/govuk/diff/pages/html_diff/runner.rb
+++ b/lib/govuk/diff/pages/html_diff/runner.rb
@@ -7,7 +7,7 @@ module Govuk
       module HtmlDiff
         class Runner
           def self.results_dir
-            File.join(Govuk::Diff::Pages.results_dir, "html-diff")
+            File.join(Govuk::Diff::Pages.results_dir, "html")
           end
 
           def self.assets_dir

--- a/lib/govuk/diff/pages/visual_diff/runner.rb
+++ b/lib/govuk/diff/pages/visual_diff/runner.rb
@@ -7,8 +7,9 @@ module Govuk
     module Pages
       module VisualDiff
         class Runner
-          def initialize(list_of_pages_uri:)
+          def initialize(list_of_pages_uri:, kernel: Kernel)
             @list_of_pages_uri = list_of_pages_uri
+            @kernel = kernel
           end
 
           def run
@@ -16,10 +17,10 @@ module Govuk
             wraith_config = WraithConfig.new(paths: paths)
             wraith_config.write
 
-            Kernel.puts "---> Creating Visual Diffs"
             cmd = "wraith capture #{wraith_config.location}"
-            Kernel.puts "running: #{cmd}"
-            Kernel.system cmd
+            puts "---> Creating Visual Diffs"
+            puts "running: #{cmd}"
+            @kernel.system cmd
 
             wraith_config.delete
           end

--- a/spec/govuk/diff/pages/html_diff/differ_spec.rb
+++ b/spec/govuk/diff/pages/html_diff/differ_spec.rb
@@ -66,7 +66,7 @@ describe Govuk::Diff::Pages::HtmlDiff::Differ do
       it 'adds the base path to the list of differing pages' do
         expect(differ).to receive(:write_diff_page).with(target_base_path, instance_of(String))
         differ.diff(target_base_path)
-        expect(differ.differing_pages[target_base_path]).to end_with("html-diff/my_base_path.html")
+        expect(differ.differing_pages[target_base_path]).to end_with("html/my_base_path.html")
       end
     end
   end

--- a/spec/govuk/diff/pages/visual_diff/runner_spec.rb
+++ b/spec/govuk/diff/pages/visual_diff/runner_spec.rb
@@ -19,7 +19,7 @@ describe Govuk::Diff::Pages::VisualDiff::Runner do
 
       expect { described_class.new(list_of_pages_uri: input_file, kernel: kernel).run }.to output(
         "---> Creating Visual Diffs\n" +
-        "running: wraith capture /var/govuk/govuk-diff-pages/config/tmp_wraith_config.yaml\n"
+        "running: wraith capture #{config_handler.location}\n"
       ).to_stdout
     end
   end

--- a/spec/govuk/diff/pages/visual_diff/runner_spec.rb
+++ b/spec/govuk/diff/pages/visual_diff/runner_spec.rb
@@ -1,20 +1,26 @@
 describe Govuk::Diff::Pages::VisualDiff::Runner do
   describe "#run" do
-    let(:yaml_file_uri) { FixtureHelper.locate("test_paths.yaml") }
-    let(:config_klass) { Govuk::Diff::Pages::VisualDiff::WraithConfig }
-    before { allow(Kernel).to receive(:puts) } # silence stdout for the test
+    let(:kernel) { double }
+    let(:input_file) { FixtureHelper.locate("test_paths.yaml") }
+    let(:config_handler_klass) { Govuk::Diff::Pages::VisualDiff::WraithConfig }
+    let(:config_handler) { config_handler_klass.new(paths: YAML.load_file(input_file)) }
+
+    before do
+      allow(config_handler_klass).to receive(:new).and_return(config_handler)
+      allow(config_handler).to receive_messages(write: nil, delete: nil)
+      allow(kernel).to receive(:system)
+    end
 
     it "executes wraith with the appropriate config" do
-      config_handler = config_klass.new(paths: ["/government/stats/foo", "/government/stats/bar"])
-      allow(config_klass).to receive(:new).and_return(config_handler)
-      allow(config_handler).to receive_messages(write: nil, delete: nil)
-
-      expect(config_klass).to receive(:new).with(paths: ["/government/stats/foo", "/government/stats/bar"])
+      expect(config_handler_klass).to receive(:new).with(paths: ["/government/stats/foo", "/government/stats/bar"])
       expect(config_handler).to receive(:write)
-      expect(Kernel).to receive(:system).with("wraith capture #{config_handler.location}")
+      expect(kernel).to receive(:system).with("wraith capture #{config_handler.location}")
       expect(config_handler).to receive(:delete)
 
-      Govuk::Diff::Pages::VisualDiff::Runner.new(list_of_pages_uri: yaml_file_uri).run
+      expect { described_class.new(list_of_pages_uri: input_file, kernel: kernel).run }.to output(
+        "---> Creating Visual Diffs\n" +
+        "running: wraith capture /var/govuk/govuk-diff-pages/config/tmp_wraith_config.yaml\n"
+      ).to_stdout
     end
   end
 end


### PR DESCRIPTION
Two bits here:
- Change how VisualDiff::Runner interacts with Kernel and clean up spec
  - Make the spec a little clearer to read.
  - Actually test the message output of #run.
  - Inject Kernel to make the dependency more obvious and testing simpler.
- Rewrite README to reflect latest state of the project
  - Includes name change of html diff results directory, for consistency.

Trello: https://trello.com/c/J6Z8RxEt/632-make-govuk-diff-pages-usable
